### PR TITLE
add company mode faces

### DIFF
--- a/noctilux-definitions.el
+++ b/noctilux-definitions.el
@@ -524,6 +524,20 @@ the \"Gen RGB\" column in noctilux-definitions.el to improve them further."
              ;;flyspell
              (flyspell-incorrect ((t (,@fg-red))))
              (flyspell-duplicate ((t (,@fg-yellow))))
+             ;; company-mode
+             (company-tooltip ((t (,@fg-base0 ,@bg-base02))))
+             (company-tooltip-selection ((t (,@fg-base0 ,@bg-base01))))
+             (company-tooltip-mouse ((t (,@bg-base02))))
+             (company-tooltip-common ((t (,@bg-base02 ,@fg-violet))))
+             (company-tooltip-common-selection ((t (,@fg-violet ,@bg-base01))))
+             (company-tooltip-annotation ((t (,@fg-base0 ,@bg-base02))))
+             (company-scrollbar-fg ((t (,@bg-base01))))
+             (company-scrollbar-bg ((t (,@bg-base3))))
+             (company-preview ((t (,@fg-base0 ,@bg-base01))))
+             (company-preview-common ((t (,@fg-base0 ,@bg-base01))))
+             (company-preview-search ((t (,@fg-violet ,@bg-base01))))
+             (company-echo ((t nil)))
+             (company-echo-common ((t (,@fg-violet))))
 	     ;;ansi-term
 	     (term-color-black ((t ( ,@fg-base02))))
 	     (term-color-red ((t ( ,@fg-red))))


### PR DESCRIPTION
No guarantees they work with all setups (I didn't test with all of the company-mode frontends), but here's a quick screenshot of most of the pseudo-tooltip:

![screen shot 2014-03-12 at 3 45 28 pm](https://f.cloud.github.com/assets/667901/2404199/5a80a602-aa38-11e3-9520-707f3fd3382a.png)

Tried to take as many cues from Light Table as possible.
