### PR TITLE
Avoid referencing a null load-file-name.

### DIFF
--- a/noctilux-theme.el
+++ b/noctilux-theme.el
@@ -681,9 +681,11 @@ the \"Gen RGB\" column in noctilux-definitions.el to improve them further."
        (provide-theme ',theme-name))))
 
 ;;;###autoload
-(when (boundp 'custom-theme-load-path)
-  (add-to-list 'custom-theme-load-path
-               (file-name-as-directory (file-name-directory load-file-name))))
+(and load-file-name
+     (boundp 'custom-theme-load-path)
+     (add-to-list 'custom-theme-load-path
+                  (file-name-as-directory
+                   (file-name-directory load-file-name))))
 
 (create-noctilux-theme)
 


### PR DESCRIPTION
load-file-name is not set when customize-theme evaluates the file, at
least in Emacs 25.